### PR TITLE
Moving indexing to 1 so .geo files work with gmsh 4.8.x

### DIFF
--- a/qmesh3/__init__.py
+++ b/qmesh3/__init__.py
@@ -29,47 +29,49 @@ import pkg_resources
 try:
     __packaged_distro__ = pkg_resources.get_distribution('qmesh3')
     __version__ = __packaged_distro__.version
-except (pkg_resources.DistributionNotFound, AttributeError):
-    __version__ = None
+except (pkg_resources.DistributionNotFound, AttributeError, NameError):
+    __version__ = "local"
     LOG.warning('Could not find qmesh version information. Provenance information is incomplete.')
 #Set the git-sha-key attribute
 try:
     __packaged_distro__.has_metadata('GIT_SHA_KEY')
     __git_sha_key__ = __packaged_distro__.get_metadata('GIT_SHA_KEY')
-except (AttributeError, FileNotFoundError):
-    __git_sha_key__ = None
+except (AttributeError, FileNotFoundError, NameError):
+    __git_sha_key__ = "local"
     LOG.warning('Could not find qmesh origin git SHA key. Provenance information is incomplete.')
 #Set the license attribute
 try:
     __packaged_distro__.has_metadata('LICENSE')
     __license__ = __packaged_distro__.get_metadata('LICENSE')
-except (AttributeError, FileNotFoundError):
-    __license__ = None
+except (AttributeError, FileNotFoundError, NameError):
+    __license__ = ""
     LOG.warning('Could not find complete license statement. Provenance information is incomplete.')
     LOG.warning('Qmesh is distributed under GPLv3. Please observe the license at .')
 #Set the authors attribute
 try:
     __packaged_distro__.has_metadata('AUTHORS.md')
     __authors__ = __packaged_distro__.get_metadata('AUTHORS.md')
-except (AttributeError, FileNotFoundError):
-    __authors__ = None
+except (AttributeError, FileNotFoundError, NameError):
+    __authors__ = ""
     LOG.warning('Could not find qmesh authors information. Provenance information is incomplete.')
 # Set the gmsh-path attribute
 try:
     __packaged_distro__.has_metadata('GMSH_BIN_PATH')
     __gmsh_bin_path__ = __packaged_distro__.get_metadata('GMSH_BIN_PATH')
-except (AttributeError, FileNotFoundError):
-    __gmsh_bin_path__ = None
+except (AttributeError, FileNotFoundError, NameError):
+    __gmsh_bin_path__ = "/usr/bin"
     LOG.warning('Could not find gmsh binary path specification. Mesh generation might fail.')
 # Set the qgis-install-path attribute
 try:
     __packaged_distro__.has_metadata('QGIS_PATH')
     __qgis_path__ = __packaged_distro__.get_metadata('QGIS_PATH')
-except (AttributeError, FileNotFoundError):
-    __qgis_path__ = None
+except (AttributeError, FileNotFoundError, NameError):
+    __qgis_path__ = "/usr/local/"
     LOG.warning('Could not find qgis path specification. qgis initialisation might fail.')
-
-del __packaged_distro__
+try:
+    del __packaged_distro__
+except NameError:
+    pass
 
 # Set-up environment and initialise qgis, without graphics.
 # Suppress verbose debugging Qt messages

--- a/qmesh3/mesh/mesh.py
+++ b/qmesh3/mesh/mesh.py
@@ -28,11 +28,11 @@ class Geometry(object):
     def __init__(self):
         """ Initialise a new Geometry object. """
         LOG.info("Initialising geometry...")
-        self.pointIndex = 0
-        self.lineIndex = 0
-        self.lineLoopIndex = 0
-        self.surfaceIndex = 0
-        self.volumeIndex = 0
+        self.pointIndex = 1
+        self.lineIndex = 1
+        self.lineLoopIndex = 1
+        self.surfaceIndex = 1
+        self.volumeIndex = 1
         self.points={}
         self.lines={}
         self.bsplines={}
@@ -74,7 +74,7 @@ class Geometry(object):
         :arg int pointIndex: The index of the point to remove.
         :rtype: None
         """
-        assert pointIndex < (len(self.points))
+        assert pointIndex < (len(self.points)+1)
         del self.points[pointIndex]
 
     def getPoint(self, pointIndex):
@@ -84,7 +84,7 @@ class Geometry(object):
         :rtype: list
         :returns: The coordinates of the point in 3D space (in a list).
         """
-        assert pointIndex < (len(self.points))
+        assert pointIndex < (len(self.points)+1)
         return self.points[pointIndex]
 
     def addPointsFromDictionary(self, pointDictionary):
@@ -108,7 +108,7 @@ class Geometry(object):
         """
         assert type(pointIndices) == list
         for pointIndex in pointIndices:
-            assert pointIndex < (len(self.points))
+            assert pointIndex < (len(self.points)+1)
         self.lines[self.lineIndex] = pointIndices
         self.lineIndex += 1
         return self.lineIndex-1
@@ -119,7 +119,7 @@ class Geometry(object):
         :arg int lineIndex: The index of the line segment in the geometry.
         :rtype: None
         """
-        assert lineIndex < (len(self.lines))
+        assert lineIndex < (len(self.lines)+1)
         del self.lines[lineIndex]
 
     def getLineSegment(self, lineIndex):
@@ -130,7 +130,7 @@ class Geometry(object):
         :returns: The line segment, in the form of a list of points.
         """
         
-        assert lineIndex < (len(self.lines))
+        assert lineIndex < (len(self.lines)+1)
         return self.lines[lineIndex]
 
     def addLineSegmentsFromDictionary(self, lineDictionary):
@@ -157,17 +157,17 @@ class Geometry(object):
     def addBspline(self, pointIndices):
         assert type(pointIndices) == list
         for pointIndex in pointIndices:
-            assert pointIndex < (len(self.points))
+            assert pointIndex < (len(self.points)+1)
         self.bsplines[self.lineIndex] = pointIndices
         self.lineIndex += 1
         return self.lineIndex-1
 
     def removeBspline(self, lineIndex):
-        assert lineIndex < (len(self.bsplines))
+        assert lineIndex < (len(self.bsplines)+1)
         del self.bsplines[lineIndex]
 
     def getBspline(self, lineIndex):
-        assert lineIndex < (len(self.bsplines))
+        assert lineIndex < (len(self.bsplines)+1)
         return self.bsplines[lineIndex]
 
     def bsplinesCount(self):
@@ -613,20 +613,20 @@ class Domain(object):
         LOG.debug('        Found '+str(pointsInLines)+' points - extracted from lines.')
         LOG.debug('        Found '+str(len(temp_pointDictionary))+' points after removing duplicates.')
         #Construct the point-dictionary now duplicates are gone.
-        pointIndex = 0
+        pointIndex = 1
         pointDictionary = {}
         for point in list(temp_pointDictionary.values()):
             pointDictionary[pointIndex] = [point.x(),point.y(), 0.0]
             pointIndex +=1
         #Construct the inverse-point-dictionary
-        pointIndex = 0
+        pointIndex = 1
         invPointDictionary = {}
         for point in list(pointDictionary.values()):
             invPointDictionary[str([point[0],point[1],0.0])] = pointIndex
             pointIndex +=1
         #Construct the line ID-point ID dictionary.
         LOG.debug('        Constructing lineID-pointID dictionary...')
-        lineIndex = 0
+        lineIndex = 1
         lineIDpointID_dictionary = {}
         for line in lines:
             pointIndices = []
@@ -637,7 +637,7 @@ class Domain(object):
             lineIndex += 1
         #Construct the ring ID-point ID dictionary and the ring-ringID dictionary.
         LOG.debug('        Constructing ringID-pointID dictionary...')
-        ringIndex = 0
+        ringIndex = 1
         ringIDPointID_dictionary = {}
         ringID_dictionary = {}
         ringsInPolygonFile = 0

--- a/qmesh3/mesh/mesh.py
+++ b/qmesh3/mesh/mesh.py
@@ -278,6 +278,7 @@ class Geometry(object):
         """
         for physicalID in physicalIDsDictionary:
             lines = physicalIDsDictionary[physicalID]
+            lines = [x+1 for x in lines]
             #TODO: check that the lines actually exist. Raise exception if it does not
             if physicalID in self.physicalLineIDs:
                 self.physicalLineIDs[physicalID] += lines
@@ -312,6 +313,7 @@ class Geometry(object):
         """
         for physicalID in physicalIDsDictionary:
             surfaces = physicalIDsDictionary[physicalID]
+            surfaces = [x+1 for x in surfaces]
             #TODO: check that the surfaces actually exist. Raise exception if it does not
             if physicalID in self.physicalSurfaceIDs:
                 self.physicalSurfaceIDs[physicalID] += surfaces

--- a/tests/unit/test_mesh/test_gmsh.py
+++ b/tests/unit/test_mesh/test_gmsh.py
@@ -114,7 +114,7 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry = qmesh3.mesh.Geometry()
         myGeometry.addPoint([0,1,1])
         myGeometry.addPoint([0,1,1])
-        self.assertTrue(myGeometry.points == {0:[0,1,1], 1:[0,1,1]})
+        self.assertTrue(myGeometry.points == {1:[0,1,1], 2:[0,1,1]})
 
     def test_remove_existing_point(self):
         #Try importing qmesh. If an ImportError exception is thrown, then
@@ -128,7 +128,7 @@ class TestGGeometryPoints(unittest.TestCase):
         qmesh3.LOG.setLevel('WARNING')
         myGeometry = qmesh3.mesh.Geometry()
         myGeometry.addPoint([0,1,1])
-        myGeometry.removePoint(0)
+        myGeometry.removePoint(1)
         self.assertTrue(myGeometry.points == {})
 
     def test_remove_nonexisting_point(self):
@@ -144,7 +144,7 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry = qmesh3.mesh.Geometry()
         myGeometry.addPoint([0,1,1])
         try:
-            myGeometry.removePoint(1)
+            myGeometry.removePoint(2)
         except AssertionError:
             self.assertTrue(True)
             return
@@ -163,10 +163,10 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry = qmesh3.mesh.Geometry()
         myGeometry.addPoint([0,1,1])
         myGeometry.addPoint([0,1,2])
-        self.assertTrue(myGeometry.getPoint(0) == [0,1,1])
-        self.assertTrue(myGeometry.getPoint(1) == [0,1,2])
+        self.assertTrue(myGeometry.getPoint(1) == [0,1,1])
+        self.assertTrue(myGeometry.getPoint(2) == [0,1,2])
         try:
-            self.assertTrue(myGeometry.getPoint(2))
+            self.assertTrue(myGeometry.getPoint(3))
         except AssertionError:
             self.assertTrue(True)
             return
@@ -205,7 +205,7 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry = qmesh3.mesh.Geometry()
         points = {0: [0,1,0], 1:[1,1,2], 2:[3,54,1]}
         myGeometry.addPointsFromDictionary(points)
-        self.assertTrue(myGeometry.getPoint(0) == [0,1,0])
+        self.assertTrue(myGeometry.getPoint(1) == [0,1,0])
 
     def test_add_points_from_dict_existing(self):
         #Try importing qmesh. If an ImportError exception is thrown, then
@@ -221,7 +221,7 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry.addPoint([0,1,1])
         points = {0: [0,1,0], 1:[1,1,2], 2:[3,54,1]}
         myGeometry.addPointsFromDictionary(points)
-        self.assertTrue(myGeometry.getPoint(0) == [0,1,1])
+        self.assertTrue(myGeometry.getPoint(1) == [0,1,1])
         self.assertTrue(myGeometry.pointsCount() == 4)
 
     def test_add_points_existing(self):
@@ -238,7 +238,7 @@ class TestGGeometryPoints(unittest.TestCase):
         myGeometry.addPoint([0,1,1])
         points = [[0,1,0], [1,1,2], [3,54,1]]
         myGeometry.addPoints(points)
-        self.assertTrue(myGeometry.getPoint(0) == [0,1,1])
+        self.assertTrue(myGeometry.getPoint(1) == [0,1,1])
         self.assertTrue(myGeometry.pointsCount() == 4)
 
 
@@ -312,10 +312,10 @@ class TestGGeometryLines(unittest.TestCase):
         G = qmesh3.mesh.Geometry()
         G.addPoints([[0,0,0], [0,1,0], [1,1,0], [1,0,0]])
         G.addLineSegment([0,1])
-        G.removeLineSegment(0)
+        G.removeLineSegment(1)
         self.assertTrue(G.lineSegmentsCount() == 0)
         try:
-            G.removeLineSegment(0)
+            G.removeLineSegment(1)
         except AssertionError:
             self.assertTrue(True)
             return
@@ -335,7 +335,7 @@ class TestGGeometryLines(unittest.TestCase):
         G.addPoints([[0,0,0], [0,1,0], [1,1,0], [1,0,0]])
         G.addLineSegment([0,1])
         self.assertTrue(G.lineSegmentsCount() == 1)
-        line = G.getLineSegment(0)
+        line = G.getLineSegment(1)
         self.assertTrue(line == [0,1])
 
 
@@ -354,7 +354,7 @@ class TestGGeometryLines(unittest.TestCase):
         G.addLineSegment([0,1])
         self.assertTrue(G.lineSegmentsCount() == 1)
         try:
-            G.getLineSegment(1)
+            G.getLineSegment(2)
         except AssertionError:
             self.assertTrue(True)
             return
@@ -447,10 +447,10 @@ class TestGGeometryBSplines(unittest.TestCase):
         G = qmesh3.mesh.Geometry()
         G.addPoints([[0,0,0], [0,1,0], [1,1,0], [1,0,0]])
         G.addBspline([0,1,2])
-        G.removeBspline(0)
+        G.removeBspline(1)
         self.assertTrue(G.bsplinesCount() == 0)
         try:
-            G.removeLineSegment(0)
+            G.removeLineSegment(1)
         except AssertionError:
             self.assertTrue(True)
             return
@@ -470,7 +470,7 @@ class TestGGeometryBSplines(unittest.TestCase):
         G.addPoints([[0,0,0], [0,1,0], [1,1,0], [1,0,0]])
         G.addBspline([0,1,2])
         self.assertTrue(G.bsplinesCount() == 1)
-        line = G.getBspline(0)
+        line = G.getBspline(1)
         self.assertTrue(line == [0,1,2])
 
 
@@ -489,7 +489,7 @@ class TestGGeometryBSplines(unittest.TestCase):
         G.addBspline([0,1,2])
         self.assertTrue(G.bsplinesCount() == 1)
         try:
-            G.getBspline(1)
+            G.getBspline(2)
         except AssertionError:
             self.assertTrue(True)
             return


### PR DESCRIPTION
Latest versions of gmsh seem to ignore Physical boundaries if line indexing starts at zero. I also fixed running tests locally if qmesh isn't installed.